### PR TITLE
OverlayTrack added

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -349,9 +349,15 @@
 				verticalDragPosition = 0;
 				scrollbarWidth = settings.verticalGutter + verticalTrack.outerWidth();
 
-				// Make the pane thinner to allow for the vertical scrollbar
-				pane.width(paneWidth - scrollbarWidth - originalPaddingTotalWidth);
-
+				if (settings.overlayTrack!==true) {
+					// Make the pane thinner to allow for the vertical scrollbar
+					pane.width(paneWidth - scrollbarWidth - originalPaddingTotalWidth);
+				}
+				else {
+					// pull vertical scrollbar same amount of it's width so it will still stay
+					// in container panel visually. 
+					verticalTrack.css({right: verticalTrack.outerWidth()});
+				}
 				// Add margin to the left of the pane if scrollbars are on that side (to position
 				// the scrollbar on the left or right set it's left or right property in CSS)
 				try {
@@ -1509,6 +1515,7 @@
 		initialDelay                : 300,        // Delay before starting repeating
 		speed						: 30,		// Default speed when others falsey
 		scrollPagePercent			: .8		// Percent of visible area scrolled when pageUp/Down or track area pressed
+		overlayTrack			: false
 	};
 
 }));


### PR DESCRIPTION

![case](https://user-images.githubusercontent.com/651202/26850242-d1645f6c-4ad4-11e7-9ce0-05c5f101bd92.png)
In some cases, we don't want panel to cut-off to show trackbar. If trackbar is positioned absolute then it can also overflow on top of panel without changing it's width attributes. Otherwise causes list items with background color set, not to fill container but leave a gap on side of the trackbar.